### PR TITLE
Remove ART Number from Patient registration

### DIFF
--- a/form/src/main/assets/questionnaires/register-patient-questionnaire.json
+++ b/form/src/main/assets/questionnaires/register-patient-questionnaire.json
@@ -44,11 +44,6 @@
       "text": "National Identification Number (NIN)"
     },
     {
-      "linkId": "art_number",
-      "type": "string",
-      "text": "ART Number"
-    },
-    {
       "linkId": "address",
       "type": "group",
       "text": "Address",


### PR DESCRIPTION
This PR removes the ART number from the patient  registration page 