### PR TITLE
update form to questionnaire mapper

### DIFF
--- a/form/src/main/java/com/lyecdevelopers/form/domain/mapper/FormMapper.kt
+++ b/form/src/main/java/com/lyecdevelopers/form/domain/mapper/FormMapper.kt
@@ -1,11 +1,15 @@
 package com.lyecdevelopers.form.domain.mapper
 
+import com.lyecdevelopers.core.data.local.entity.FormEntity
 import com.lyecdevelopers.core.model.FieldType
-import com.lyecdevelopers.core.model.o3.o3Form
+import org.hl7.fhir.r4.model.CodeType
+import org.hl7.fhir.r4.model.CodeableConcept
+import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.Extension
 import org.hl7.fhir.r4.model.Questionnaire
 
 object FormMapper {
-    fun toQuestionnaire(form: o3Form): Questionnaire {
+    fun toQuestionnaire(form: FormEntity): Questionnaire {
         val questionnaire = Questionnaire().apply {
             id = form.uuid
             title = form.name
@@ -25,6 +29,7 @@ object FormMapper {
                     linkId = section.label
                     text = section.label
                     type = Questionnaire.QuestionnaireItemType.GROUP
+
                 }
 
                 section.questions.forEach { question ->
@@ -34,25 +39,188 @@ object FormMapper {
                         type = when (question.questionoptions.rendering) {
                             FieldType.NUMBER -> Questionnaire.QuestionnaireItemType.DECIMAL
                             FieldType.DATE -> Questionnaire.QuestionnaireItemType.DATE
-                            FieldType.TEXT -> Questionnaire.QuestionnaireItemType.STRING
-                            FieldType.TEXTAREA -> Questionnaire.QuestionnaireItemType.STRING
-                            FieldType.DATETIME -> Questionnaire.QuestionnaireItemType.DATE
+                            FieldType.DATETIME -> Questionnaire.QuestionnaireItemType.DATETIME
+                            FieldType.TEXT,
+                            FieldType.TEXTAREA,
+                                -> {
+                                this.extension.add(
+                                    Extension().apply {
+                                        url =
+                                            "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+                                        setValue(
+                                            CodeableConcept().addCoding(
+                                                Coding().apply {
+                                                    system =
+                                                        "http://hl7.org/fhir/questionnaire-item-control"
+                                                    code = "text-box"
+                                                    display = "text box"
+                                                })
+                                        )
+
+                                    })
+
+
+                                Questionnaire.QuestionnaireItemType.STRING
+                            }
                             FieldType.DROPDOWN,
                             FieldType.SELECT,
-                            FieldType.RADIO,
-                                -> Questionnaire.QuestionnaireItemType.CHOICE
+                                -> {
+                                extension.add(
+                                    Extension().apply {
+                                        url =
+                                            "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+                                        setValue(
+                                            CodeableConcept().addCoding(
+                                                Coding().apply {
+                                                    system =
+                                                        "http://hl7.org/fhir/questionnaire-item-control"
+                                                    code = "drop-down"
+                                                    display = "Dropdown"
+                                                })
+                                        )
 
-                            FieldType.CHECKBOX,
-                            FieldType.MULTI_CHECKBOX,
-                                -> Questionnaire.QuestionnaireItemType.GROUP
+                                    },
+                                )
+
+                                // Add options
+                                question.questionoptions.answers?.forEach { answer ->
+                                    addAnswerOption(
+                                        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+                                            .apply {
+                                                value = Coding().apply {
+                                                    code = answer.concept
+                                                    display = answer.label
+                                                }
+                                            },
+                                    )
+                                }
+
+                                Questionnaire.QuestionnaireItemType.CHOICE
+                            }
+
+                            FieldType.RADIO -> {
+                                extension.add(
+                                    Extension().apply {
+                                        url =
+                                            "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+                                        setValue(
+                                            CodeableConcept().addCoding(
+                                                Coding().apply {
+                                                    system =
+                                                        "http://hl7.org/fhir/questionnaire-item-control"
+                                                    code = "radio-button"
+                                                    display = "radio button"
+                                                },
+                                            )
+                                        )
+                                    },
+                                )
+
+                                extension.add(
+                                    Extension().apply {
+                                        url =
+                                            "http://hl7.org/fhir/StructureDefinition/questionnaire-choiceOrientation"
+                                        setValue(
+                                            CodeType(
+                                                "horizontal"
+                                            )
+                                        )
+
+                                    },
+                                )
+
+                                // Add options
+                                question.questionoptions.answers?.forEach { answer ->
+                                    addAnswerOption(
+                                        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+                                            .apply {
+                                                value = Coding().apply {
+                                                    code = answer.concept
+                                                    display = answer.label
+                                                }
+                                            },
+                                    )
+                                }
+
+                                Questionnaire.QuestionnaireItemType.CHOICE
+                            }
+
+                            FieldType.CHECKBOX -> {
+                                extension.add(
+                                    Extension().apply {
+                                        url =
+                                            "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+                                        setValue(
+                                            CodeableConcept().addCoding(
+                                                Coding().apply {
+                                                    system =
+                                                        "http://hl7.org/fhir/questionnaire-item-control"
+                                                    code = "check-box"
+                                                    display = "Checkbox"
+                                                },
+                                            )
+                                        )
+                                    },
+                                )
+
+                                // Add options
+                                question.questionoptions.answers?.forEach { answer ->
+                                    addAnswerOption(
+                                        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+                                            .apply {
+                                                value = Coding().apply {
+                                                    code = answer.concept
+                                                    display = answer.label
+                                                }
+                                            },
+                                    )
+                                }
+                                Questionnaire.QuestionnaireItemType.CHOICE
+                            }
+
+                            FieldType.MULTI_CHECKBOX -> {
+                                repeats = true
+                                extension.add(
+                                    Extension().apply {
+                                        url =
+                                            "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"
+                                        setValue(
+                                            CodeableConcept().addCoding(
+                                                Coding().apply {
+                                                    system =
+                                                        "http://hl7.org/fhir/questionnaire-item-control"
+                                                    code = "check-box"
+                                                    display = "Checkbox"
+                                                },
+                                            )
+                                        )
+                                    },
+                                )
+
+                                // Add answer options
+                                question.questionoptions.answers?.forEach { answer ->
+                                    addAnswerOption(
+                                        Questionnaire.QuestionnaireItemAnswerOptionComponent()
+                                            .apply {
+                                                value = Coding().apply {
+                                                    code = answer.concept
+                                                    display = answer.label
+                                                }
+                                            },
+                                    )
+                                }
+
+                                Questionnaire.QuestionnaireItemType.CHOICE
+                            }
+
 
                             else -> Questionnaire.QuestionnaireItemType.STRING
                         }
                     }
 
-
                     sectionGroup.addItem(item)
                 }
+
 
                 pageGroup.addItem(sectionGroup)
             }


### PR DESCRIPTION
The `FormMapper` now converts `FormEntity` to `Questionnaire`. It also enhances the mapping of various field types, including:
- Text and Textarea fields are mapped to STRING with a "text-box" item control.
- Dropdown, Select, and Radio fields are mapped to CHOICE with appropriate item controls ("drop-down", "radio-button") and answer options.
- Checkbox and Multi-Checkbox fields are mapped to CHOICE with a "check-box" item control and answer options. Multi-Checkbox also sets `repeats` to true.