### PR TITLE
Refactor: QuestionnaireViewModel and FormsViewModel

### DIFF
--- a/form/src/main/java/com/lyecdevelopers/form/data/repository/PatientRepositoryImpl.kt
+++ b/form/src/main/java/com/lyecdevelopers/form/data/repository/PatientRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.database.sqlite.SQLiteDatabaseCorruptException
 import android.database.sqlite.SQLiteDatabaseLockedException
 import android.database.sqlite.SQLiteException
 import androidx.paging.PagingSource
+import com.google.android.fhir.FhirEngine
 import com.lyecdevelopers.core.data.local.dao.PatientDao
 import com.lyecdevelopers.core.data.local.entity.PatientEntity
 import com.lyecdevelopers.core.model.PatientWithVisits
@@ -21,6 +22,7 @@ import javax.inject.Inject
 
 class PatientRepositoryImpl @Inject constructor(
     private val patientDao: PatientDao,
+    private val fhirEngine: FhirEngine,
 ) : PatientRepository {
     override suspend fun getPatientWithVisits(patientId: String): Flow<Result<PatientWithVisits?>> =
         patientDao.observePatientWithVisits(patientId) // updated to the Flow version
@@ -38,9 +40,11 @@ class PatientRepositoryImpl @Inject constructor(
 
 
     override suspend fun createInFhir(patient: Patient) {
+        fhirEngine.create(patient)
     }
 
     override suspend fun updateInFhir(patient: Patient) {
+        fhirEngine.update(patient)
     }
 
     override suspend fun saveToLocalDb(entity: PatientEntity) {

--- a/form/src/main/java/com/lyecdevelopers/form/di/FormModule.kt
+++ b/form/src/main/java/com/lyecdevelopers/form/di/FormModule.kt
@@ -57,9 +57,10 @@ object FormModule {
     @Singleton
     fun providePatientRepository(
         patientDao: PatientDao,
+        fhirEngine: FhirEngine,
     ): PatientRepository {
         return PatientRepositoryImpl(
-            patientDao = patientDao,
+            patientDao = patientDao, fhirEngine = fhirEngine
         )
     }
 }

--- a/form/src/main/java/com/lyecdevelopers/form/presentation/forms/FormsScreen.kt
+++ b/form/src/main/java/com/lyecdevelopers/form/presentation/forms/FormsScreen.kt
@@ -87,7 +87,7 @@ fun FormsScreen(
                         items(
                             forms,
                             key = { it.uuid ?: it.name ?: it.hashCode().toString() }) { form ->
-                            form.name?.let { name ->
+                            form.name?.let {
                                 Surface(
                                     modifier = Modifier
                                         .fillMaxWidth()

--- a/form/src/main/java/com/lyecdevelopers/form/presentation/questionnaire/event/QuestionnaireEvent.kt
+++ b/form/src/main/java/com/lyecdevelopers/form/presentation/questionnaire/event/QuestionnaireEvent.kt
@@ -1,15 +1,14 @@
 package com.lyecdevelopers.form.presentation.questionnaire.event
 
-import org.hl7.fhir.r4.model.Patient
+import org.hl7.fhir.r4.model.Questionnaire
 
 sealed class QuestionnaireEvent {
     object Load : QuestionnaireEvent()
     data class UpdateAnswer(val linkId: String, val answer: Any?) : QuestionnaireEvent()
-    object Submit : QuestionnaireEvent()
     data class SubmitWithResponse(val questionnaireResponseJson: String) :
         QuestionnaireEvent()
 
-    data class LoadForEdit(val patient: Patient) : QuestionnaireEvent()
+    data class LoadForEdit(val questionnaire: Questionnaire) : QuestionnaireEvent()
     object Reset : QuestionnaireEvent()
 }
 


### PR DESCRIPTION
- Remove unused FhirEngine dependency and related logic from QuestionnaireViewModel.
- Simplify state updates and error handling in QuestionnaireViewModel.
- Update `loadQuestionnaireByUuid` to use `getLocalFormById`.
- Remove `Submit` event and related logic from QuestionnaireViewModel as it's handled by `SubmitWithResponse`.
- Update `LoadForEdit` event to take a Questionnaire object.
- Inject FhirEngine into PatientRepositoryImpl for FHIR operations.
- Update FormsViewModel to use a more generic `handleResult` function for state updates.